### PR TITLE
Refactoring/chat history evaluating

### DIFF
--- a/chat/services.py
+++ b/chat/services.py
@@ -145,15 +145,15 @@ class ChatService:
         return score, feedback
     
     def check_level_up(self, session: ChatSession):
-        # 최근 10개 메시지의 평균 점수가 4.5점 이상이면 레벨업
+        # 최근 10개 메시지의 평균 점수가 4.0점 이상이면 레벨업
         recent_messages = session.messages.filter(
             sender='child',
             evaluation_score__isnull=False
         ).order_by('-created_at')[:10]
         
-        if len(recent_messages) >= 5:
+        if len(recent_messages) >= 10:
             avg_score = sum(msg.evaluation_score for msg in recent_messages) / len(recent_messages)
-            if avg_score >= 4.5:
+            if avg_score >= 4.0:
                 return True
         return False
     

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -4,5 +4,5 @@ from . import views
 urlpatterns = [
     path('start/', views.ChatSessionView.as_view(), name='start_chat'),
     path('message/', views.ChatMessageView.as_view(), name='send_message'),
-    path('history/<int:child_id>/', views.ChatHistoryView.as_view(), name='chat_history'),
+    path('history/', views.ChatHistoryView.as_view(), name='chat_history'),
 ]

--- a/chat/views.py
+++ b/chat/views.py
@@ -159,15 +159,20 @@ class ChatHistoryView(APIView):
     @swagger_auto_schema(
         operation_summary="채팅 기록 조회",
         operation_description="특정 아이의 최근 채팅 세션 기록을 조회합니다.",
-        manual_parameters=[
-            openapi.Parameter('child_id', openapi.IN_PATH, description="아이 ID", type=openapi.TYPE_INTEGER),
-        ],
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            required=['child_id'],
+            properties={
+                'child_id': openapi.Schema(type=openapi.TYPE_INTEGER, description='아이 ID'),
+            }
+        ),
         responses={
             200: ChatSessionSerializer(many=True),
             404: openapi.Response(description='아이를 찾을 수 없음'),
         }
     )
-    def get(self, request, child_id):
+    def post(self, request):
+        child_id = request.data.get('child_id')
         child = get_object_or_404(ChildUser, id=child_id)
         sessions = ChatSession.objects.filter(child=child).order_by('-created_at')[:10]
         serializer = ChatSessionSerializer(sessions, many=True)


### PR DESCRIPTION
## 📌 Refactor/chat history evaluating
[refactor/#이슈번호]chat API / 채팅 기록 요청 방식 및 레벨업 기준 개선

## ✅ 작업 내용
- 채팅 기록 API를 URL 파라미터에서 request body 방식으로 변경
- 레벨업 평균 점수 기준을 4.5점에서 4.0점으로 완화
- ChatHistoryView HTTP 메서드를 GET에서 POST로 변경
- URL 패턴에서 child_id 파라미터 제거


## 🔁 관련 이슈
- close #이슈번호
